### PR TITLE
Update igdbURL to v3 endpoint

### DIFF
--- a/igdb.go
+++ b/igdb.go
@@ -10,7 +10,7 @@ import (
 )
 
 // igdbURL is the base URL for the IGDB API.
-const igdbURL string = "https://api-2445582011268.apicast.io/"
+const igdbURL string = "https://api-v3.igdb.com/"
 
 // Errors returned when creating URLs for API calls.
 var (


### PR DESCRIPTION
Wanted to start playing around with the IGDB API, but it turns out that new API keys are only valid for this new API v3 endpoint. 

I'm not sure if more changes are probably in order for v3 compatibility: https://api-docs.igdb.com/#migration-to-v3