### PR TITLE
Add missing documentation

### DIFF
--- a/ageratingcontent.go
+++ b/ageratingcontent.go
@@ -20,6 +20,7 @@ type AgeRatingContentCategory int
 
 //go:generate stringer -type=AgeRatingContentCategory
 
+// Expected AgeRatingContentCategory enums from the IGDB.
 const (
 	AgeRatingContentPEGI AgeRatingContentCategory = iota + 1
 	AgeRatingContentESRB

--- a/alternativename.go
+++ b/alternativename.go
@@ -8,6 +8,9 @@ import (
 
 //go:generate gomodifytags -file $GOFILE -struct AlternativeName -add-tags json -w
 
+// AlternativeName represents an alternative or international
+// name for a particular video game.
+// For more information visit: https://api-docs.igdb.com/#alternative-name
 type AlternativeName struct {
 	ID      int    `json:"id"`
 	Comment string `json:"comment"`


### PR DESCRIPTION
Missed a couple of exported types and constants when adding missing documentation.