### PR TITLE
adding new Game Category enum values

### DIFF
--- a/achievementrank_string.go
+++ b/achievementrank_string.go
@@ -4,6 +4,16 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[RankBronze-1]
+	_ = x[RankSilver-2]
+	_ = x[RankGold-3]
+	_ = x[RankPlatinum-4]
+}
+
 const _AchievementRank_name = "RankBronzeRankSilverRankGoldRankPlatinum"
 
 var _AchievementRank_index = [...]uint8{0, 10, 20, 28, 40}
@@ -14,6 +24,14 @@ func (i AchievementRank) String() string {
 		return "AchievementRank(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _AchievementRank_name[_AchievementRank_index[i]:_AchievementRank_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[AchievementPlaystation-1]
+	_ = x[AchievementXbox-2]
+	_ = x[AchievementSteam-3]
 }
 
 const _AchievementCategory_name = "AchievementPlaystationAchievementXboxAchievementSteam"
@@ -26,6 +44,21 @@ func (i AchievementCategory) String() string {
 		return "AchievementCategory(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _AchievementCategory_name[_AchievementCategory_index[i]:_AchievementCategory_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[LanguageEurope-1]
+	_ = x[LanguageNorthAmerica-2]
+	_ = x[LanguageAustralia-3]
+	_ = x[LanguageNewZealand-4]
+	_ = x[LanguageJapan-5]
+	_ = x[LanguageChina-6]
+	_ = x[LanguageAsia-7]
+	_ = x[LanguageWorldwide-8]
+	_ = x[LanguageHongKong-9]
+	_ = x[LanguageSouthKorea-10]
 }
 
 const _AchievementLanguage_name = "LanguageEuropeLanguageNorthAmericaLanguageAustraliaLanguageNewZealandLanguageJapanLanguageChinaLanguageAsiaLanguageWorldwideLanguageHongKongLanguageSouthKorea"

--- a/ageratingcategory_string.go
+++ b/ageratingcategory_string.go
@@ -4,6 +4,14 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[AgeRatingESRB-1]
+	_ = x[AgeRatingPEGI-2]
+}
+
 const _AgeRatingCategory_name = "AgeRatingESRBAgeRatingPEGI"
 
 var _AgeRatingCategory_index = [...]uint8{0, 13, 26}
@@ -14,6 +22,23 @@ func (i AgeRatingCategory) String() string {
 		return "AgeRatingCategory(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _AgeRatingCategory_name[_AgeRatingCategory_index[i]:_AgeRatingCategory_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[AgeRatingThree-1]
+	_ = x[AgeRatingSeven-2]
+	_ = x[AgeRatingTwelve-3]
+	_ = x[AgeRatingSixteen-4]
+	_ = x[AgeRatingEighteen-5]
+	_ = x[AgeRatingRP-6]
+	_ = x[AgeRatingEC-7]
+	_ = x[AgeRatingE-8]
+	_ = x[AgeRatingE10-9]
+	_ = x[AgeRatingT-10]
+	_ = x[AgeRatingM-11]
+	_ = x[AgeRatingAO-12]
 }
 
 const _AgeRatingEnum_name = "AgeRatingThreeAgeRatingSevenAgeRatingTwelveAgeRatingSixteenAgeRatingEighteenAgeRatingRPAgeRatingECAgeRatingEAgeRatingE10AgeRatingTAgeRatingMAgeRatingAO"

--- a/ageratingcontentcategory_string.go
+++ b/ageratingcontentcategory_string.go
@@ -4,6 +4,14 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[AgeRatingContentPEGI-1]
+	_ = x[AgeRatingContentESRB-2]
+}
+
 const _AgeRatingContentCategory_name = "AgeRatingContentPEGIAgeRatingContentESRB"
 
 var _AgeRatingContentCategory_index = [...]uint8{0, 20, 40}

--- a/charactergender_string.go
+++ b/charactergender_string.go
@@ -4,6 +4,15 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[GenderMale-1]
+	_ = x[GenderFemale-2]
+	_ = x[GenderOther-3]
+}
+
 const _CharacterGender_name = "GenderMaleGenderFemaleGenderOther"
 
 var _CharacterGender_index = [...]uint8{0, 10, 22, 33}
@@ -14,6 +23,16 @@ func (i CharacterGender) String() string {
 		return "CharacterGender(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _CharacterGender_name[_CharacterGender_index[i]:_CharacterGender_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[SpeciesHuman-1]
+	_ = x[SpeciesAlien-2]
+	_ = x[SpeciesAnimal-3]
+	_ = x[SpeciesAndroid-4]
+	_ = x[SpeciesUnknown-5]
 }
 
 const _CharacterSpecies_name = "SpeciesHumanSpeciesAlienSpeciesAnimalSpeciesAndroidSpeciesUnknown"

--- a/creditcategory_string.go
+++ b/creditcategory_string.go
@@ -4,6 +4,18 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[CreditVoiceActor-1]
+	_ = x[CreditLanguage-2]
+	_ = x[CreditCompany-3]
+	_ = x[CreditEmployee-4]
+	_ = x[CreditMisc-5]
+	_ = x[CreditSupportCompany-6]
+}
+
 const _CreditCategory_name = "CreditVoiceActorCreditLanguageCreditCompanyCreditEmployeeCreditMiscCreditSupportCompany"
 
 var _CreditCategory_index = [...]uint8{0, 16, 30, 43, 57, 67, 87}

--- a/datecategory_string.go
+++ b/datecategory_string.go
@@ -4,6 +4,20 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[DateYYYYMMMMDD-0]
+	_ = x[DateYYYYMMMM-1]
+	_ = x[DateYYYY-2]
+	_ = x[DateYYYYQ1-3]
+	_ = x[DateYYYYQ2-4]
+	_ = x[DateYYYYQ3-5]
+	_ = x[DateYYYYQ4-6]
+	_ = x[DateTBD-7]
+}
+
 const _DateCategory_name = "DateYYYYMMMMDDDateYYYYMMMMDateYYYYDateYYYYQ1DateYYYYQ2DateYYYYQ3DateYYYYQ4DateTBD"
 
 var _DateCategory_index = [...]uint8{0, 14, 26, 34, 44, 54, 64, 74, 81}
@@ -13,6 +27,19 @@ func (i DateCategory) String() string {
 		return "DateCategory(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _DateCategory_name[_DateCategory_index[i]:_DateCategory_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[RegionEurope-1]
+	_ = x[RegionNorthAmerica-2]
+	_ = x[RegionAustralia-3]
+	_ = x[RegionNewZealand-4]
+	_ = x[RegionJapan-5]
+	_ = x[RegionChina-6]
+	_ = x[RegionAsia-7]
+	_ = x[RegionWorldwide-8]
 }
 
 const _RegionCategory_name = "RegionEuropeRegionNorthAmericaRegionAustraliaRegionNewZealandRegionJapanRegionChinaRegionAsiaRegionWorldwide"

--- a/enums_test.go
+++ b/enums_test.go
@@ -130,6 +130,9 @@ func TestGameCategory(t *testing.T) {
 		{"Expansion", GameCategory(2), "Expansion"},
 		{"Bundle", GameCategory(3), "Bundle"},
 		{"Standalone expansion", GameCategory(4), "Standalone Expansion"},
+		{"Mod", GameCategory(5), "Mod"},
+		{"Episode", GameCategory(6), "Episode"},
+		{"Season", GameCategory(7), "Episode"},
 		{"Undefined default", GameCategory(100), "Undefined"},
 	}
 	for _, tt := range gameTests {

--- a/externalgamecategory_string.go
+++ b/externalgamecategory_string.go
@@ -4,6 +4,19 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ExternalSteam-1]
+	_ = x[ExternalGOG-5]
+	_ = x[ExternalYoutube-10]
+	_ = x[ExternalMicrosoft-11]
+	_ = x[ExternalApple-13]
+	_ = x[ExternalTwitch-14]
+	_ = x[ExternalAndroid-15]
+}
+
 const (
 	_ExternalGameCategory_name_0 = "ExternalSteam"
 	_ExternalGameCategory_name_1 = "ExternalGOG"

--- a/feedcategory_string.go
+++ b/feedcategory_string.go
@@ -4,6 +4,18 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[FeedPulseArticle-1]
+	_ = x[FeedComingSoon-2]
+	_ = x[FeedNewTrailer-3]
+	_ = x[FeedUserContributedItem-5]
+	_ = x[FeedUserContributionsItem-6]
+	_ = x[FeedPageContributedItem-7]
+}
+
 const (
 	_FeedCategory_name_0 = "FeedPulseArticleFeedComingSoonFeedNewTrailer"
 	_FeedCategory_name_1 = "FeedUserContributedItemFeedUserContributionsItemFeedPageContributedItem"

--- a/game.go
+++ b/game.go
@@ -77,6 +77,9 @@ const (
 	Expansion
 	Bundle
 	StandaloneExpansion
+	Mod
+	Episode
+	Season
 )
 
 // GameStatus specifies the release status of a specific game.

--- a/gamecategory_string.go
+++ b/gamecategory_string.go
@@ -4,15 +4,40 @@ package igdb
 
 import "strconv"
 
-const _GameCategory_name = "MainGameDLCAddonExpansionBundleStandaloneExpansion"
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[MainGame-0]
+	_ = x[DLCAddon-1]
+	_ = x[Expansion-2]
+	_ = x[Bundle-3]
+	_ = x[StandaloneExpansion-4]
+	_ = x[Mod-5]
+	_ = x[Episode-6]
+	_ = x[Season-7]
+}
 
-var _GameCategory_index = [...]uint8{0, 8, 16, 25, 31, 50}
+const _GameCategory_name = "MainGameDLCAddonExpansionBundleStandaloneExpansionModEpisodeSeason"
+
+var _GameCategory_index = [...]uint8{0, 8, 16, 25, 31, 50, 53, 60, 66}
 
 func (i GameCategory) String() string {
 	if i < 0 || i >= GameCategory(len(_GameCategory_index)-1) {
 		return "GameCategory(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _GameCategory_name[_GameCategory_index[i]:_GameCategory_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[StatusReleased-0]
+	_ = x[StatusAlpha-2]
+	_ = x[StatusBeta-3]
+	_ = x[StatusEarlyAccess-4]
+	_ = x[StatusOffline-5]
+	_ = x[StatusCancelled-6]
 }
 
 const (

--- a/pagecategory_string.go
+++ b/pagecategory_string.go
@@ -4,6 +4,16 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[PagePersonality-1]
+	_ = x[PageMediaOrganization-2]
+	_ = x[PageContentCreator-3]
+	_ = x[PageClanTeam-4]
+}
+
 const _PageCategory_name = "PagePersonalityPageMediaOrganizationPageContentCreatorPageClanTeam"
 
 var _PageCategory_index = [...]uint8{0, 15, 36, 54, 66}
@@ -14,6 +24,17 @@ func (i PageCategory) String() string {
 		return "PageCategory(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _PageCategory_name[_PageCategory_index[i]:_PageCategory_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[PageUser-1]
+	_ = x[PageGame-2]
+	_ = x[PageCompany-3]
+	_ = x[PageConsumer-4]
+	_ = x[PageIndustry-5]
+	_ = x[PageESports-6]
 }
 
 const _PageSubCategory_name = "PageUserPageGamePageCompanyPageConsumerPageIndustryPageESports"
@@ -26,6 +47,17 @@ func (i PageSubCategory) String() string {
 		return "PageSubCategory(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _PageSubCategory_name[_PageSubCategory_index[i]:_PageSubCategory_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[PageGreen-0]
+	_ = x[PageBlue-1]
+	_ = x[PageRed-2]
+	_ = x[PageOrange-3]
+	_ = x[PagePink-4]
+	_ = x[PageYellow-5]
 }
 
 const _PageColor_name = "PageGreenPageBluePageRedPageOrangePagePinkPageYellow"

--- a/platformcategory_string.go
+++ b/platformcategory_string.go
@@ -4,6 +4,18 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[PlatformConsole-1]
+	_ = x[PlatformArcade-2]
+	_ = x[PlatformPlatform-3]
+	_ = x[PlatformOperatingSystem-4]
+	_ = x[PlatformPortableConsole-5]
+	_ = x[PlatformComputer-6]
+}
+
 const _PlatformCategory_name = "PlatformConsolePlatformArcadePlatformPlatformPlatformOperatingSystemPlatformPortableConsolePlatformComputer"
 
 var _PlatformCategory_index = [...]uint8{0, 15, 29, 45, 68, 91, 107}

--- a/reviewcategory_string.go
+++ b/reviewcategory_string.go
@@ -4,6 +4,14 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ReviewText-1]
+	_ = x[ReviewVid-2]
+}
+
 const _ReviewCategory_name = "ReviewTextReviewVid"
 
 var _ReviewCategory_index = [...]uint8{0, 10, 19}

--- a/socialmetriccategory_string.go
+++ b/socialmetriccategory_string.go
@@ -4,6 +4,19 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[SocialFollows-1]
+	_ = x[SocialLikes-2]
+	_ = x[SocialHates-3]
+	_ = x[SocialShares-4]
+	_ = x[SocialViews-5]
+	_ = x[SocialComments-6]
+	_ = x[SocialFavorites-7]
+}
+
 const _SocialMetricCategory_name = "SocialFollowsSocialLikesSocialHatesSocialSharesSocialViewsSocialCommentsSocialFavorites"
 
 var _SocialMetricCategory_index = [...]uint8{0, 13, 24, 35, 47, 58, 72, 87}

--- a/testdummyenum_string.go
+++ b/testdummyenum_string.go
@@ -4,6 +4,14 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[TestDummyEnum1-1]
+	_ = x[TestDummyEnum2-2]
+}
+
 const _TestDummyEnum_name = "TestDummyEnum1TestDummyEnum2"
 
 var _TestDummyEnum_index = [...]uint8{0, 14, 28}

--- a/versionfeaturecategory_string.go
+++ b/versionfeaturecategory_string.go
@@ -4,6 +4,14 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[VersionFeatureBoolean-0]
+	_ = x[VersionFeatureDescription-1]
+}
+
 const _VersionFeatureCategory_name = "VersionFeatureBooleanVersionFeatureDescription"
 
 var _VersionFeatureCategory_index = [...]uint8{0, 21, 46}

--- a/versionfeatureinclusion_string.go
+++ b/versionfeatureinclusion_string.go
@@ -4,6 +4,15 @@ package igdb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[VersionFeatureNotIncluded-0]
+	_ = x[VersionFeatureIncluded-1]
+	_ = x[VersionFeaturePreOrderOnly-2]
+}
+
 const _VersionFeatureInclusion_name = "VersionFeatureNotIncludedVersionFeatureIncludedVersionFeaturePreOrderOnly"
 
 var _VersionFeatureInclusion_index = [...]uint8{0, 25, 47, 73}


### PR DESCRIPTION
Updated Game Category enums to support the values:

- mod, 5
- episode, 6
- season, 7

IGDB documentation:
https://api-docs.igdb.com/#game-enums

I regenerated the `go generate` files via `stringer` and looks like more recent versions output an additional `func` than originally.