### PR TITLE
Adding additional values for Game Category enums

### DIFF
--- a/enums_test.go
+++ b/enums_test.go
@@ -132,7 +132,12 @@ func TestGameCategory(t *testing.T) {
 		{"Standalone expansion", GameCategory(4), "Standalone Expansion"},
 		{"Mod", GameCategory(5), "Mod"},
 		{"Episode", GameCategory(6), "Episode"},
-		{"Season", GameCategory(7), "Episode"},
+		{"Season", GameCategory(7), "Season"},
+		{"Remake", GameCategory(8), "Remake"},
+		{"Remaster", GameCategory(9), "Remaster"},
+		{"ExpandedGame", GameCategory(10), "ExpandedGame"},
+		{"Port", GameCategory(11), "Port"},
+		{"Fork", GameCategory(12), "Fork"},
 		{"Undefined default", GameCategory(100), "Undefined"},
 	}
 	for _, tt := range gameTests {

--- a/enums_test.go
+++ b/enums_test.go
@@ -138,6 +138,8 @@ func TestGameCategory(t *testing.T) {
 		{"ExpandedGame", GameCategory(10), "ExpandedGame"},
 		{"Port", GameCategory(11), "Port"},
 		{"Fork", GameCategory(12), "Fork"},
+		{"Pack", GameCategory(13), "Pack"},
+		{"Update", GameCategory(14), "Update"},
 		{"Undefined default", GameCategory(100), "Undefined"},
 	}
 	for _, tt := range gameTests {

--- a/game.go
+++ b/game.go
@@ -77,6 +77,11 @@ const (
 	Mod
 	Episode
 	Season
+	Remake
+	Remaster
+	ExpandedGame
+	Port
+	Fork
 )
 
 // GameStatus specifies the release status of a specific game.

--- a/game.go
+++ b/game.go
@@ -1,9 +1,10 @@
 package igdb
 
 import (
+	"strconv"
+
 	"github.com/Henry-Sarabia/sliceconv"
 	"github.com/pkg/errors"
-	"strconv"
 )
 
 //go:generate gomodifytags -file $GOFILE -struct Game -add-tags json -w
@@ -82,6 +83,8 @@ const (
 	ExpandedGame
 	Port
 	Fork
+	Pack
+	Update
 )
 
 // GameStatus specifies the release status of a specific game.

--- a/gamecategory_string.go
+++ b/gamecategory_string.go
@@ -21,11 +21,13 @@ func _() {
 	_ = x[ExpandedGame-10]
 	_ = x[Port-11]
 	_ = x[Fork-12]
+	_ = x[Pack-13]
+	_ = x[Update-14]
 }
 
-const _GameCategory_name = "MainGameDLCAddonExpansionBundleStandaloneExpansionModEpisodeSeasonRemakeRemasterExpandedGamePortFork"
+const _GameCategory_name = "MainGameDLCAddonExpansionBundleStandaloneExpansionModEpisodeSeasonRemakeRemasterExpandedGamePortForkPackUpdate"
 
-var _GameCategory_index = [...]uint8{0, 8, 16, 25, 31, 50, 53, 60, 66, 72, 80, 92, 96, 100}
+var _GameCategory_index = [...]uint8{0, 8, 16, 25, 31, 50, 53, 60, 66, 72, 80, 92, 96, 100, 104, 110}
 
 func (i GameCategory) String() string {
 	if i < 0 || i >= GameCategory(len(_GameCategory_index)-1) {

--- a/gamecategory_string.go
+++ b/gamecategory_string.go
@@ -16,11 +16,16 @@ func _() {
 	_ = x[Mod-5]
 	_ = x[Episode-6]
 	_ = x[Season-7]
+	_ = x[Remake-8]
+	_ = x[Remaster-9]
+	_ = x[ExpandedGame-10]
+	_ = x[Port-11]
+	_ = x[Fork-12]
 }
 
-const _GameCategory_name = "MainGameDLCAddonExpansionBundleStandaloneExpansionModEpisodeSeason"
+const _GameCategory_name = "MainGameDLCAddonExpansionBundleStandaloneExpansionModEpisodeSeasonRemakeRemasterExpandedGamePortFork"
 
-var _GameCategory_index = [...]uint8{0, 8, 16, 25, 31, 50, 53, 60, 66}
+var _GameCategory_index = [...]uint8{0, 8, 16, 25, 31, 50, 53, 60, 66, 72, 80, 92, 96, 100}
 
 func (i GameCategory) String() string {
 	if i < 0 || i >= GameCategory(len(_GameCategory_index)-1) {


### PR DESCRIPTION
IGDB updated with new values for [Game categories](https://api-docs.igdb.com/#game):
- Remake
- Remaster
- ExpandedGame
- Port
- Fork

The PR adds them to be recognized by the library.